### PR TITLE
Add REPL utils

### DIFF
--- a/resources/leiningen/new/trapperkeeper/README.md
+++ b/resources/leiningen/new/trapperkeeper/README.md
@@ -6,12 +6,25 @@ A trapperkeeper web app designed to ... well, that part is up to you.
 
 First, run:
 
-`lein tk`
+    $ lein tk
 
-Then, open a browser and visit:
+Then, open a browser and visit: `http://localhost:8080/hello/{{name}}`
 
-http://localhost:8080/hello/{{name}}
+### Running from the REPL
 
+Alternately, run:
+
+    $ lein repl
+    nREPL server started on port 52137 on host 127.0.0.1
+    user => (go)
+
+This will allow you to launch the app from the Clojure REPL. You can then make
+changes and run `(reset)` to reload the app or `(stop)` to shutdown the app.
+
+In addition, the functions `(context)` and `(print-context)` are available to
+print out the current trapperkeeper application context. Both of these take an
+optional array of keys as a parameter, which is used to retrieve a nested
+subset of the context map.
 
 ## License
 

--- a/resources/leiningen/new/trapperkeeper/project.clj
+++ b/resources/leiningen/new/trapperkeeper/project.clj
@@ -13,10 +13,14 @@
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]]
 
-  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
+  :profiles {:dev {:source-paths ["dev"]
+                   :dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]
                                   [clj-http "0.9.2"]
+                                  [org.clojure/tools.namespace "0.2.4"]
                                   [ring-mock "0.1.5"]]}}
+
+  :repl-options {:init-ns user}
 
   :aliases {"tk" ["trampoline" "run" "--config" "dev-resources/config.conf"]}
 

--- a/resources/leiningen/new/trapperkeeper/user.clj
+++ b/resources/leiningen/new/trapperkeeper/user.clj
@@ -1,0 +1,57 @@
+(ns user
+  (:require [clojure.pprint :as pprint]
+            [clojure.tools.namespace.repl :refer [refresh]]
+            [puppetlabs.trapperkeeper.app :as tka]
+            [puppetlabs.trapperkeeper.bootstrap :as bootstrap]
+            [puppetlabs.trapperkeeper.config :as config]
+            [puppetlabs.trapperkeeper.core :as tk]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Basic system life cycle
+
+(def system nil)
+
+(defn init []
+  (alter-var-root #'system
+                  (fn [_] (tk/build-app
+                            (bootstrap/parse-bootstrap-config! "./dev-resources/bootstrap.cfg")
+                            (config/load-config "./dev-resources/config.conf"))))
+  (alter-var-root #'system tka/init)
+  (tka/check-for-errors! system))
+
+(defn start []
+  (alter-var-root #'system
+                  (fn [s] (if s (tka/start s))))
+  (tka/check-for-errors! system))
+
+(defn stop []
+  (alter-var-root #'system
+                  (fn [s] (when s (tka/stop s)))))
+
+(defn go []
+  (init)
+  (start))
+
+(defn reset []
+  (stop)
+  (refresh :after 'user/go))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Utilities for interacting with running system
+
+(defn context
+  "Get the current TK application context.  Accepts an optional array
+  argument, which is treated as a sequence of keys to retrieve a nested
+  subset of the map (a la `get-in`)."
+  ([]
+   (context []))
+  ([keys]
+   (get-in @(tka/app-context system) keys)))
+
+(defn print-context
+  "Pretty-print the current TK application context.  Accepts an optional
+  array of keys (a la `get-in`) to print a nested subset of the context."
+  ([]
+   (print-context []))
+  ([keys]
+   (pprint/pprint (context keys))))

--- a/src/leiningen/new/trapperkeeper.clj
+++ b/src/leiningen/new/trapperkeeper.clj
@@ -37,4 +37,5 @@ Accepts a group id in the project name: `lein new trapperkeeper foo.bar/baz`"
              ["dev-resources/config.conf" (render "dev-resources/config.conf" data)]
              ["dev-resources/logback-dev.xml" (render "dev-resources/logback-dev.xml" data)]
              ["dev-resources/logback-test.xml" (render "dev-resources/logback-test.xml" data)]
+             ["dev/user.clj" (render "user.clj" data)]
              "resources")))


### PR DESCRIPTION
Add helper functions to `dev/user.clj` to allow the app to be easily run from
the REPL. The same config files used in the `lein tk` alias are used when
running from the REPL.

In addition, add `dev/` as `source-path` for the dev profile in project.clj,
and pass `:init-ns user` as a repl option so that after running `lein repl` a
user can just run `(go)` without having to do anything else.