### PR TITLE
(SERVER-532) Change equals signs to colons in config file

### DIFF
--- a/resources/leiningen/new/trapperkeeper/dev-resources/config.conf
+++ b/resources/leiningen/new/trapperkeeper/dev-resources/config.conf
@@ -1,10 +1,10 @@
 global {
-    logging-config = ./dev-resources/logback-dev.xml
+    logging-config: ./dev-resources/logback-dev.xml
 }
 
 webserver {
-    host = localhost
-    port = 8080
+    host: localhost
+    port: 8080
 }
 
 web-router-service: {


### PR DESCRIPTION
To conform our standard of using JSON-style HOCON and not using equals signs.