### PR TITLE
(TK-350) Prep for 1.3.0 release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject trapperkeeper/lein-template "1.1.0"
+(defproject trapperkeeper/lein-template "1.3.0-SNAPSHOT"
   :eval-in-leiningen true
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"

--- a/resources/leiningen/new/trapperkeeper/project.clj
+++ b/resources/leiningen/new/trapperkeeper/project.clj
@@ -1,14 +1,25 @@
-(def ks-version "1.0.0")
-(def tk-version "1.0.0")
-(def tk-jetty9-version "1.0.0")
+(def ks-version "1.3.0")
+(def tk-version "1.3.1")
+(def tk-jetty9-version "1.5.5")
 
 (defproject {{raw-name}} "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [compojure "1.2.0"]
+
+  :pedantic? :abort
+
+  :dependencies [[org.clojure/clojure "1.8.0"]
+
+                 ;; explicit versions of deps that would cause transitive dep conflicts
+                 [org.clojure/tools.reader "1.0.0-beta1"]
+                 [slingshot "0.12.2"]
+                 [clj-time "0.9.0"]
+                 ;; end explicit versions of deps that would cause transitive dep conflicts
+
+
+                 [compojure "1.5.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]]
@@ -16,8 +27,8 @@
   :profiles {:dev {:source-paths ["dev"]
                    :dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]
-                                  [clj-http "0.9.2"]
-                                  [org.clojure/tools.namespace "0.2.4"]
+                                  [clj-http "3.0.0"]
+                                  [org.clojure/tools.namespace "0.2.11"]
                                   [ring-mock "0.1.5"]]}}
 
   :repl-options {:init-ns user}


### PR DESCRIPTION
This commit updates all of the dependencies to the latest
versions of the various PL/TK components, to prepare for a
new 1.3.0 release of the template.