### PR TITLE
Use puppetlabs/clj-parent for dependency resolution

### DIFF
--- a/resources/leiningen/new/trapperkeeper/project.clj
+++ b/resources/leiningen/new/trapperkeeper/project.clj
@@ -1,40 +1,33 @@
-(def ks-version "1.3.0")
-(def tk-version "1.3.1")
-(def tk-jetty9-version "1.5.5")
-
 (defproject {{raw-name}} "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
+  :min-lein-version "2.7.1"
+
+  :parent-project {:coords [puppetlabs/clj-parent "1.1.0"]
+                   :inherit [:managed-dependencies]}
+
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.8.0"]
-
-                 ;; explicit versions of deps that would cause transitive dep conflicts
-                 [org.clojure/tools.reader "1.0.0-beta1"]
-                 [slingshot "0.12.2"]
-                 [clj-time "0.10.0"]
-                 [puppetlabs/kitchensink "1.3.0"]
-                 [org.clojure/tools.macro "0.1.5"]
-                 ;; end explicit versions of deps that would cause transitive dep conflicts
-
-                 [puppetlabs/comidi "0.3.1"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]]
+  :dependencies [[org.clojure/clojure]
+                 [puppetlabs/comidi]
+                 [puppetlabs/trapperkeeper]
+                 [puppetlabs/trapperkeeper-webserver-jetty9]]
 
   :profiles {:dev {:source-paths ["dev"]
-                   :dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
-                                  [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]
-                                  [clj-http "3.0.0"]
-                                  [org.clojure/tools.namespace "0.2.11"]
-                                  [ring-mock "0.1.5"]]}}
+                   :dependencies [[puppetlabs/trapperkeeper :classifier "test" :scope "test"]
+                                  [puppetlabs/kitchensink :classifier "test" :scope "test"]
+                                  [clj-http "3.6.0"]
+                                  [org.clojure/tools.namespace]
+                                  [ring-mock]]}}
 
   :repl-options {:init-ns user}
 
   :aliases {"tk" ["trampoline" "run" "--config" "dev-resources/config.conf"]}
+
+  :plugins [[lein-parent "0.3.1"]]
 
   :main puppetlabs.trapperkeeper.main
 


### PR DESCRIPTION

Introducing `puppetlabs/clj-parent` for `managed-dependencies`. Should make maintenance of this template's dependencies a lot easier.